### PR TITLE
updated peachpie and request pipeline

### DIFF
--- a/ResponsiveFileManager.AspNetCore/RequestDelegateExtension.cs
+++ b/ResponsiveFileManager.AspNetCore/RequestDelegateExtension.cs
@@ -1,7 +1,12 @@
 ﻿using System.IO;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Pchp.Core;
+using ResponsiveFileManager;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -16,13 +21,24 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The application builder.</param>
         public static IApplicationBuilder UseResponsiveFileManager(this IApplicationBuilder app)
         {
+            const string filemanagerPath = "/filemanager";
+
             app.UseStaticFiles(new StaticFileOptions
             {
-                RequestPath = new PathString("/filemanager"),
-                FileProvider = new PhysicalFileProvider(Path.GetFullPath(Path.Combine(Assembly.GetEntryAssembly().Location, "../filemanager"))),
+                RequestPath = filemanagerPath,
+                FileProvider = new PhysicalFileProvider(Path.GetFullPath(Path.Combine(Assembly.GetEntryAssembly().Location, ".." + filemanagerPath))),
             });
 
-            app.UsePhp();
+            app.UsePhp(filemanagerPath, (Context ctx) =>
+            {
+                // construct the options
+                var options = new ResponsiveFileManagerOptions();
+                ctx.GetService<IConfiguration>().GetSection("ResponsiveFileManagerOptions").Bind(options);
+                ctx.GetService<IConfigureOptions<ResponsiveFileManagerOptions>>()?.Configure(options);
+
+                // pass the options object to PHP globals
+                ctx.Globals["rfm_options"] = PhpValue.FromClass(options);
+            });
 
             return app;
         }

--- a/ResponsiveFileManager.AspNetCore/ResponsiveFileManager.AspNetCore.csproj
+++ b/ResponsiveFileManager.AspNetCore/ResponsiveFileManager.AspNetCore.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Title>Responsive File Manager for ASP.NET Core</Title>
     <Description>The whole of Responsive File Manager, compiled, packed and provided as an ASP.NET Core package. Does not require PHP, becomes a part of ASP.NET Core application.
 
 Usage:
@@ -25,11 +26,12 @@ Usage:
 
   <ItemGroup>
     <PackageReference Include="Peachpie.AspNetCore.Web" Version="$(PeachpieVersion)" />
-  </ItemGroup>
 
-  <ItemGroup>
     <ProjectReference Include="..\ResponsiveFileManager\ResponsiveFileManager.msbuildproj">
       <PrivateAssets>None</PrivateAssets>
     </ProjectReference>
+
+    <None Include="..\README.md" Pack="true" PackagePath="assets/readme.md" />
+
   </ItemGroup>
 </Project>

--- a/ResponsiveFileManager.AspNetCore/ServiceCollectionExtensions.cs
+++ b/ResponsiveFileManager.AspNetCore/ServiceCollectionExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
-using Pchp.Core;
 using ResponsiveFileManager;
 
 namespace Microsoft.AspNetCore.Builder
@@ -26,16 +23,7 @@ namespace Microsoft.AspNetCore.Builder
 
             services.AddPhp(options =>
             {
-                options.RequestStart += (Context ctx) =>
-                {
-                    // construct the options
-                    var options = new ResponsiveFileManagerOptions();
-                    ctx.GetService<IConfiguration>().GetSection("ResponsiveFileManagerOptions").Bind(options);
-                    ctx.GetService<IConfigureOptions<ResponsiveFileManagerOptions>>()?.Configure(options);
-
-                    // pass the options object to PHP globals
-                    ctx.Globals["rfm_options"] = PhpValue.FromClass(options);
-                };
+                //
             });
 
             //

--- a/ResponsiveFileManager/ResponsiveFileManager.manifest
+++ b/ResponsiveFileManager/ResponsiveFileManager.manifest
@@ -1,0 +1,3 @@
+﻿{
+  "delisted": true
+}

--- a/ResponsiveFileManager/ResponsiveFileManager.msbuildproj
+++ b/ResponsiveFileManager/ResponsiveFileManager.msbuildproj
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <Title>Responsive File Manager</Title>
     <Product>Responsive File Manager</Product>
     <Description>Responsive File Manager running on .NET Core with Peachpie</Description>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -21,6 +22,8 @@
       <PackageCopyToOutput>true</PackageCopyToOutput>
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
+
+    <None Include="ResponsiveFileManager.manifest" Pack="true" PackagePath="ResponsiveFileManager.manifest" />
 
   </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "Peachpie.NET.Sdk": "0.9.990"
+        "Peachpie.NET.Sdk": "1.0.0-preview1"
     }
 }


### PR DESCRIPTION
this PR updates PeachPie to `1.0.0-preview1` and improves request pipeline so it is configured only for `/filemanager` path prefix (as discussed before, in case the client would like to have more PHP application wihtin the request pipeline)

Also it adds readme into the NuGet package.